### PR TITLE
Only send requestid for post requests since post requests cover modif…

### DIFF
--- a/lib/qbo_api.rb
+++ b/lib/qbo_api.rb
@@ -111,7 +111,7 @@ class QboApi
 
   def request(method, path:, entity: nil, payload: nil, params: nil)
     raw_response = connection.send(method) do |req|
-      path = finalize_path(path, params: params)
+      path = finalize_path(path, method: method, params: params)
       case method
       when :get, :delete
         req.url path

--- a/lib/qbo_api/util.rb
+++ b/lib/qbo_api/util.rb
@@ -17,8 +17,8 @@ class QboApi
       SecureRandom.uuid
     end
 
-    def finalize_path(path, params: nil)
-      path = add_request_id_to(path)
+    def finalize_path(path, method:, params: nil)
+      path = add_request_id_to(path) if method == :post
       path = add_minor_version_to(path)
       path = add_params_to_path(path: path, params: params) if params
       path

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -30,8 +30,16 @@ describe QboApi::Util do
       QboApi.request_id = true
       api = QboApi.new(creds.to_h)
       path = api.entity_path(:tax_code)
-      path = api.finalize_path(path, params: { other: 12345 })
+      path = api.finalize_path(path, method: :post, params: { other: 12345 })
       expect(path).to match /other=12345$/
+    end
+
+    it "requestid is not implemented for non-post requests" do
+      QboApi.request_id = true
+      api = QboApi.new(creds.to_h)
+      path = api.entity_path(:tax_code)
+      path = api.finalize_path(path, method: :get, params: { other: 12345 })
+      expect(path).to_not match /requestid=/
     end
   end
 


### PR DESCRIPTION
…y, create, and delete operations, which are the only operations in where a requestid may be needed