### PR TITLE
Fix bug that singularized 'Class' to 'Clas'

### DIFF
--- a/lib/qbo_api/entity.rb
+++ b/lib/qbo_api/entity.rb
@@ -4,9 +4,9 @@ class QboApi
     def singular(entity)
       e = snake_to_camel(entity)
       case e
-      when 'Classes'
+      when 'Classes', 'Class'
         'Class'
-      when /^(Entitlements|Preferences)$/
+      when 'Entitlements', 'Preferences'
         e
       else
         e.chomp('s')


### PR DESCRIPTION
When using a select statement with singular "Class" (ex: "Select * from Class"), #singular was changing the entity name to "Clas". This caused #entity_response to deliver the raw response in JSON instead of only an array of the objects in the response.