### PR TITLE
Change QboApi#all to return enumerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,23 +243,23 @@ See [docs](https://developer.intuit.com/docs/0100_quickbooks_online/0100_essenti
 ### Import/retrieve all
 ```ruby
   # retrieves all active customers
-  qbo_api.all(:customers) do |c|
+  qbo_api.all(:customers).each do |c|
     p "#{c['Id']} #{c['DisplayName']}"
   end
 
   # retrieves all active or inactive employees
-  qbo_api.all(:employees, inactive: true) do |e|
+  qbo_api.all(:employees, inactive: true).each do |e|
     p "#{e['Id']} #{e['DisplayName']}"
   end
 
   # retrieves all vendors by groups of 5
-  qbo_api.all(:vendor, max: 5) do |v|
+  qbo_api.all(:vendor, max: 5).each do |v|
     p v['DisplayName']
   end
   
   # retrieves all customers by groups of 2 using a custom select query
   where = "WHERE Id IN ('5', '6', '7', '8', '9', '10')"
-  qbo_api.all(:customer, max: 2, select: "SELECT * FROM Customer #{where}") do |c|
+  qbo_api.all(:customer, max: 2, select: "SELECT * FROM Customer #{where}").each do |c|
     p c['DisplayName']
   end
 ```

--- a/spec/all_spec.rb
+++ b/spec/all_spec.rb
@@ -2,67 +2,67 @@ require 'spec_helper'
 
 describe "QboApi Import All entities" do
   context ".all" do
+    context "backwards compatability (with block)" do
+      it 'retrieves all customers' do
+        api = QboApi.new(creds.to_h)
+        counter = []
+        VCR.use_cassette("qbo_api/all/customers", record: :none) do
+          result = api.query("SELECT COUNT(*) FROM Customer")
+          count = result['QueryResponse']['totalCount']
+          response = api.all(:customers) do |c|
+            counter << "#{c['Id']} #{c['DisplayName']}"
+          end
+          expect(counter.size).to eq count
+        end
+      end
+    end
+
     it 'retrieves all customers' do
       api = QboApi.new(creds.to_h)
-      counter = []
       VCR.use_cassette("qbo_api/all/customers", record: :none) do
         result = api.query("SELECT COUNT(*) FROM Customer")
         count = result['QueryResponse']['totalCount']
-        response = api.all(:customers) do |c|
-          counter << "#{c['Id']} #{c['DisplayName']}"
-        end
-        expect(counter.size).to eq count
+        response = api.all(:customers)
+        expect(response.count).to eq count
       end
     end
 
     it 'retrieves all employees including inactive ones' do
       api = QboApi.new(creds.to_h)
-      counter = []
       VCR.use_cassette("qbo_api/all/employees_including_active", record: :none) do
         result = api.query("SELECT COUNT(*) FROM Employee WHERE Active IN (true, false) ")
         count = result['QueryResponse']['totalCount']
-        response = api.all(:employees, inactive: true) do |c|
-          counter << "#{c['Id']} #{c['DisplayName']}"
-        end
-        expect(counter.size).to eq count
+        response = api.all(:employees, inactive: true)
+        expect(response.count).to eq count
       end
     end
 
     it 'retrieves all vendors by groups of 5' do
       api = QboApi.new(creds.to_h)
-      counter = []
       VCR.use_cassette("qbo_api/all/vendors_by_5", record: :none) do
         result = api.query("SELECT COUNT(*) FROM Vendor")
         count = result['QueryResponse']['totalCount']
-        response = api.all(:vendor, max: 5) do |c|
-          counter << c['DisplayName']
-        end
-        expect(counter.size).to eq count
+        response = api.all(:vendor, max: 5)
+        expect(response.count).to eq count
       end
     end
 
     it 'retrieves all customers, including inactive ones, by groups of 2 by alternate select query' do
       api = QboApi.new(creds.to_h)
-      counter = []
       where = "WHERE Id IN ('5', '6', '7', '8', '9', '10')"
       VCR.use_cassette("qbo_api/all/alt_select", record: :none) do
         result = api.query("SELECT count(*) FROM Customer #{where}")
         count = result['QueryResponse']['totalCount']
-        response = api.all(:customer, max: 2, select: "SELECT * FROM Customer #{where}", inactive: true) do |c|
-          counter << c['DisplayName']
-        end
-        expect(counter.size).to eq count
+        response = api.all(:customer, max: 2, select: "SELECT * FROM Customer #{where}", inactive: true)
+        expect(response.count).to eq count
       end
     end
 
     it 'retrieves sales receipts' do
       api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/all/sales_receipts", record: :none) do
-        gather = []
-        api.all(:sales_receipts) do |s|
-          gather << s['Id']
-        end
-        expect(gather.first).to eq "47"
+        first_id = api.all(:sales_receipts).first['Id']
+        expect(first_id).to eq "47"
       end
     end
 

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -9,7 +9,7 @@ describe QboApi::Util do
 
   it 'convert Time objects to proper CDC "changed since" time stamp' do
     api = QboApi.new(creds.to_h)
-    expect(api.cdc_time(Time.now)).to match /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2}$/
+    expect(api.cdc_time(Time.now)).to match /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/
   end
 
   describe '.esc' do


### PR DESCRIPTION
This allow doing all sorts of crazy stuff that enumerators allow
```ruby
api.all(:clients).each do |client|
  # do stuff with this client
end

api.all(:clients).count
api.all(:clients).first
api.all(:clients).to_a # to get all clients
```

So you don't have to do stuff like
```ruby
clients = []
api.all(:clients) do |client|
  clients << client
end
```
This breaks API however