### PR TITLE
Fix issue with recording fault type in JSON response

### DIFF
--- a/lib/qbo_api/raise_http_exception.rb
+++ b/lib/qbo_api/raise_http_exception.rb
@@ -55,7 +55,7 @@ module FaradayMiddleware
       r = res['Fault']['Error']
       r.collect do |e|
         {
-          fault_type: e['type'],
+          fault_type: res['Fault']['type'],
           error_code: e['code'],
           error_message: e['Message'],
           error_detail: e['Detail']


### PR DESCRIPTION
The fault type of JSON error responses was not being recorded correctly, unless there are alternate formats that I an unaware of.