### PR TITLE
Fix issue with #query not extracting entity when query ends with entity name

### DIFF
--- a/lib/qbo_api/entity.rb
+++ b/lib/qbo_api/entity.rb
@@ -82,7 +82,7 @@ class QboApi
     end
 
     def extract_entity_from_query(query, to_sym: false)
-      if m = query.match(/from\s+(\w+)\s/i)
+      if m = query.match(/from\s+(\w+)(?:$|\s)/i)
         (to_sym ? underscore(m[1]).to_sym : m[1]) if m[1]
       end
     end


### PR DESCRIPTION
I noticed that when using #query, a query that ends immediately after the entity name does not extract the entity automatically.

When query ends with entity name:
```ruby
>> qb_service.query("SELECT * FROM Invoice")
=> {"QueryResponse"=>
  {"Invoice"=>
    [{"Deposit"=>0,
      "AllowIPNPayment"=>false,
      ...
      "Balance"=>100.0,
      "HomeBalance"=>100.0}],
   "startPosition"=>1,
   "maxResults"=>1,
   "totalCount"=>1},
 "time"=>"2017-09-22T15:59:21.433-07:00"}
```

When query does not end with entity name (space after 'Invoice'):
```ruby
>> qb_service.query("SELECT * FROM Invoice ")
=> [{"Deposit"=>0,
  "AllowIPNPayment"=>false,
  ...
  "Balance"=>100.0,
  "HomeBalance"=>100.0}]
```