### PR TITLE
Add support for JSON error responses with all lowercase keys.

### DIFF
--- a/lib/qbo_api/raise_http_exception.rb
+++ b/lib/qbo_api/raise_http_exception.rb
@@ -52,13 +52,14 @@ module FaradayMiddleware
 
     def parse_json(body)
       res = ::JSON.parse(body)
-      r = res['Fault']['Error']
-      r.collect do |e|
+      fault = res['Fault'] || res['fault']
+      errors = fault['Error'] || fault['error']
+      errors.collect do |error|
         {
-          fault_type: res['Fault']['type'],
-          error_code: e['code'],
-          error_message: e['Message'],
-          error_detail: e['Detail']
+          fault_type: fault['type'],
+          error_code: error['code'],
+          error_message: error['Message'] || error['message'],
+          error_detail: error['Detail'] || error['detail']
         }
       end
     end


### PR DESCRIPTION
This is a fix for the behavior described in #39. See there for details.