### PR TITLE
Add support for custom middleware and parallel requests

### DIFF
--- a/lib/qbo_api.rb
+++ b/lib/qbo_api.rb
@@ -40,7 +40,7 @@ class QboApi
   end
 
   def connection(url: get_endpoint)
-    Faraday.new(url: url) do |faraday|
+    @connection ||= Faraday.new(url: url) do |faraday|
       faraday.headers['Content-Type'] = 'application/json;charset=UTF-8'
       faraday.headers['Accept'] = "application/json"
       if @token != nil


### PR DESCRIPTION
This PR stores the connection as an instance variable so that the Faraday middleware can be edited (before first use of the connection). In my case it was to add the `:retry` middleware, and custom middleware to sleep and retry when QboApi::TooManyRequests is encountered.

It also allows for parallel requests (with an appropriate Faraday adapter), since the connection is not re-instantiated for each QboApi request. This means that you can do something like this:

```ruby
qbo_api.connection.in_parallel do
  qbo_api.batch(payload1)
  qbo_api.batch(payload2)
  qbo_api.batch(payload3)
end
```

As far as I could tell, there is no reason for the connection to be instantiated on each request, hence the minimal change. It seems that even when doing a successful `#reconnect`, the tokens, keys, and secrets are not swapped out, and a new QboApi instance must be created because there is not attr_writer for those variables. Please let me know if there's some necessary case for re-instantiated connections and I will accomodate.