### PR TITLE
Specs to oauth2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,13 @@
 /tmp/
 .env
 .ruby-version
+.ruby-gemset
+.byebug_history
 *.gem
 .rspec
 todo.txt
 *.sess
 *.log
+spec/temp/spec_status.txt
+*.swp
 scrap.txt

--- a/spec/all_spec.rb
+++ b/spec/all_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
 
 describe "QboApi Import All entities" do
+  let(:api){ QboApi.new(creds.to_h) }
+  
   context ".all" do
     context "backwards compatability (with block)" do
       it 'retrieves all customers' do
-        api = QboApi.new(creds.to_h)
         counter = []
         VCR.use_cassette("qbo_api/all/customers", record: :none) do
           result = api.query("SELECT COUNT(*) FROM Customer")
@@ -18,7 +19,6 @@ describe "QboApi Import All entities" do
     end
 
     it 'retrieves all customers' do
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/all/customers", record: :none) do
         result = api.query("SELECT COUNT(*) FROM Customer")
         count = result['QueryResponse']['totalCount']
@@ -28,7 +28,6 @@ describe "QboApi Import All entities" do
     end
 
     it 'retrieves all employees including inactive ones' do
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/all/employees_including_active", record: :none) do
         result = api.query("SELECT COUNT(*) FROM Employee WHERE Active IN (true, false) ")
         count = result['QueryResponse']['totalCount']
@@ -38,7 +37,6 @@ describe "QboApi Import All entities" do
     end
 
     it 'retrieves all vendors by groups of 5' do
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/all/vendors_by_5", record: :none) do
         result = api.query("SELECT COUNT(*) FROM Vendor")
         count = result['QueryResponse']['totalCount']
@@ -48,7 +46,6 @@ describe "QboApi Import All entities" do
     end
 
     it 'retrieves all customers, including inactive ones, by groups of 2 by alternate select query' do
-      api = QboApi.new(creds.to_h)
       where = "WHERE Id IN ('5', '6', '7', '8', '9', '10')"
       VCR.use_cassette("qbo_api/all/alt_select", record: :none) do
         result = api.query("SELECT count(*) FROM Customer #{where}")
@@ -59,7 +56,6 @@ describe "QboApi Import All entities" do
     end
 
     it 'retrieves sales receipts' do
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/all/sales_receipts", record: :none) do
         first_id = api.all(:sales_receipts).first['Id']
         expect(first_id).to eq "47"

--- a/spec/attachment_spec.rb
+++ b/spec/attachment_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe "QboApi Attachment" do
 
+  let(:api){ QboApi.new(creds.to_h) }
+
   it 'for an invoice is successfully created' do
     payload = {
       "AttachableRef":
@@ -16,7 +18,6 @@ describe "QboApi Attachment" do
        "FileName": "no_detail.xml",
        "ContentType": "text/xml"
     }
-    api = QboApi.new(creds.to_h)
     VCR.use_cassette("qbo_api/create/attachment_for_invoice", record: :none) do
       response = api.upload_attachment(payload: payload, attachment: fixture_path + '/no_detail.xml')
       expect(response['Id']).to_not be_nil
@@ -37,7 +38,6 @@ describe "QboApi Attachment" do
        "FileName": "no_detail.xml",
        "ContentType": "text/xml"
     }
-    api = QboApi.new(creds.to_h)
     VCR.use_cassette("qbo_api/error/attachment_estimate", record: :none) do
       response = api.upload_attachment(payload: payload, attachment: fixture_path + '/no_detail.xml')
       expect(response).to include { ['AttachableResponse'].first['Fault'] }

--- a/spec/create_update_delete_spec.rb
+++ b/spec/create_update_delete_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe "QboApi Create Update Delete" do
+
+  let(:api){ QboApi.new(creds.to_h) }
+
   context ".create" do
 
     after do
@@ -25,7 +28,6 @@ describe "QboApi Create Update Delete" do
           "value": "1"
         }
       }
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/create/invoice", record: :none) do
         response = api.create(:invoice, payload: invoice)
         #p response['Id']
@@ -36,7 +38,6 @@ describe "QboApi Create Update Delete" do
     it 'a customer using a request id' do
       customer = { DisplayName: 'Doe, Jane' }
       QboApi.request_id = true
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/create/customer", record: :none) do
         response = api.create(:customer, payload: customer)
         expect(response['Id']).to_not be_nil
@@ -56,7 +57,6 @@ describe "QboApi Create Update Delete" do
         }
       }
       QboApi.minor_version = 8
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/update/customer", record: :none) do
         # Use the id of the created customer above
         response = api.update(:customer, id: 60, payload: customer)
@@ -66,7 +66,6 @@ describe "QboApi Create Update Delete" do
     end
 
     it 'a sales receipt with minor version and request id set for the individual request' do
-      api = QboApi.new(creds.to_h)
       sales_receipt = {
         Line: [
           {
@@ -97,7 +96,6 @@ describe "QboApi Create Update Delete" do
 
   context '.delete' do
     it 'an invoice' do
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/delete/invoice", record: :none) do
         # Use the id of the created invoice above
         response = api.delete(:invoice, id: 145)
@@ -106,14 +104,12 @@ describe "QboApi Create Update Delete" do
     end
 
     it 'only a transaction entity' do
-      api = QboApi.new(creds.to_h)
       expect { response = api.delete(:customer, id: 145) }.to raise_error QboApi::NotImplementedError, /^Delete is only for/
     end
   end
 
   context '.deactivate' do
     it 'an employee' do
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/deactivate/employee", record: :none) do
         response = api.deactivate(:employee, id: 55)
         expect(response['Active']).to eq false
@@ -121,7 +117,6 @@ describe "QboApi Create Update Delete" do
     end
 
     it 'an account' do
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/deactivate/account", record: :none) do
         response = api.deactivate(:account, id: 5)
         expect(response['Active']).to eq false
@@ -129,7 +124,6 @@ describe "QboApi Create Update Delete" do
     end
 
     it 'only a name list entity' do
-      api = QboApi.new(creds.to_h)
       expect { response = api.deactivate(:refund_receipt, id: 145) }.to raise_error QboApi::NotImplementedError, /^Deactivate is only for/
     end
   end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe "QboApi Error handling" do
+
+  let(:api){ QboApi.new(creds.to_h) }
+
   it 'handles a 404 error' do
     api = QboApi.new(creds.to_h.merge(token: 12345))
     VCR.use_cassette("qbo_api/error/401", record: :none) do
@@ -21,14 +24,12 @@ describe "QboApi Error handling" do
   end
 
   it 'handles a 400 JSON error' do
-    api = QboApi.new(creds.to_h)
     VCR.use_cassette("qbo_api/error/400_json", record: :none) do
       expect{ response = api.create(:invoice, payload: { 'BadJson': true }) }.to raise_error QboApi::BadRequest
     end
   end
 
   it 'handles a 500 error' do
-    api = QboApi.new(creds.to_h)
     VCR.use_cassette("qbo_api/error/500", record: :none) do
       expect{ response = api.get(:customer, '1/5') }.to raise_error QboApi::InternalServerError
     end
@@ -36,7 +37,6 @@ describe "QboApi Error handling" do
 
   it 'handles a validation error' do
     customer = { DisplayName: 'Weiskopf Consulting' }
-    api = QboApi.new(creds.to_h)
     VCR.use_cassette("qbo_api/error/validation", record: :none) do
       begin
         response = api.create(:customer, payload: customer)

--- a/spec/finder_spec.rb
+++ b/spec/finder_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe QboApi::Finder do
 
-  let(:api) { QboApi.new(creds.to_h)}
+  let(:api) { QboApi.new(creds.to_h) }
 
   it '.to_quote_or_not' do
     ['true', 'false', 'CURRENT_DATE', '( true, false)'].each do |str|

--- a/spec/oauth2_spec.rb
+++ b/spec/oauth2_spec.rb
@@ -8,12 +8,14 @@ describe QboApi do
       expect { api.get :customer, 5 }.to raise_error QboApi::Error, "Must set either the token or access_token"
     end
 
-    it 'to do a basic .get request' do
-      creds = oauth2_creds
-      api = QboApi.new(creds.to_h)
-      VCR.use_cassette("qbo_api/oauth2/basic_get", record: :none) do
-        response = api.get(:customer, 5)
-        expect(response['DisplayName']).to eq "Dukes Basketball Camp"
+    if ENV['QBO_API_OAUTH2_ACCESS_TOKEN']
+      #if the OAUTH2 access token is not nil then the creds will be the OAuth2 creds
+      it 'to do a basic .get request' do
+        api = QboApi.new(creds.to_h)
+        VCR.use_cassette("qbo_api/oauth2/basic_get", record: :none) do
+          response = api.get(:customer, 5)
+          expect(response['DisplayName']).to eq "Dukes Basketball Camp"
+        end
       end
     end
   end

--- a/spec/qbo_api_spec.rb
+++ b/spec/qbo_api_spec.rb
@@ -1,12 +1,14 @@
 require 'spec_helper'
 
 describe QboApi do
+
+  let(:api){ QboApi.new(creds.to_h) }
+
   it 'has a version number' do
     expect(QboApi::VERSION).not_to be nil
   end
 
   it '.snake_to_camel' do
-    api = QboApi.new(creds.to_h)
     res = %w(SalesReceipt CreditMemo Customer)
     %i(sales_receipt credit_memo customer).each_with_index do |s, index|
       expect(api.snake_to_camel(s)).to eq res[index]
@@ -14,7 +16,6 @@ describe QboApi do
   end
 
   it '.singular' do
-    api = QboApi.new(creds.to_h)
     res = %w(Invoice Preferences Entitlements Class Vendor)
     %i(invoices preferences entitlements classes vendor).each_with_index do |s, index|
       expect(api.singular(s)).to eq res[index]
@@ -22,7 +23,6 @@ describe QboApi do
   end
 
   it '.is_transaction_entity?' do
-    api = QboApi.new(creds.to_h)
     expect(api.is_transaction_entity?(:invoice)).to be true
     expect(api.is_transaction_entity?(:invoices)).to be true
     expect(api.is_transaction_entity?(:customer)).to be false
@@ -30,7 +30,6 @@ describe QboApi do
   end
 
   it '.is_name_list_entity?' do
-    api = QboApi.new(creds.to_h)
     expect(api.is_name_list_entity?(:vendors)).to be true
     expect(api.is_name_list_entity?(:classes)).to be true
     expect(api.is_name_list_entity?(:payment_method)).to be true
@@ -38,7 +37,6 @@ describe QboApi do
   end
 
   it '.extract_entity_from_query' do
-    api = QboApi.new(creds.to_h)
     expect(api.extract_entity_from_query('Select * FROM Invoice WHERE')).to eq "Invoice"
     expect(api.extract_entity_from_query('Select count(*) fROM PurchaseOrder WHERE DisplayName =')).to eq "PurchaseOrder"
     expect(api.extract_entity_from_query('Select # invoice WHERE')).to be nil
@@ -46,7 +44,6 @@ describe QboApi do
   end
 
   it '.get_endpoint' do
-    api = QboApi.new(creds.to_h)
     expect(api.send(:get_endpoint)).to eq QboApi::V3_ENDPOINT_BASE_URL
     QboApi.production = true
     expect(api.send(:get_endpoint)).to_not match /sandbox/

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -1,9 +1,12 @@
 require 'spec_helper'
 
 describe "QboApi::Query" do
+
+  let(:api){ QboApi.new(creds.to_h) }
+
+
   context ".cdc" do
     it 'should grab estimates via change data capture query' do
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/cdc/basic", record: :none) do
         response = api.cdc(entities: 'estimate', changed_since: '2011-10-10T09:00:00-07:00')
         expect(response['CDCResponse'].size).to eq 1

--- a/spec/reconnect_and_disconnect_spec.rb
+++ b/spec/reconnect_and_disconnect_spec.rb
@@ -1,9 +1,12 @@
 require 'spec_helper'
 
 describe QboApi do
+
+  let(:api){ QboApi.new(creds.to_h) }
+
+
   context 'reconnect' do
     it 'out of bounds' do
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/reconnect/out_of_bounds", record: :none) do
         response = api.reconnect
         expect(response['ErrorCode']).to eq 212

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,6 +56,7 @@ end
 
 
 RSpec.configure do |config|
+  config.example_status_persistence_file_path = 'spec/temp/spec_status.txt'
 end
 
 def endpoint

--- a/spec/support/credentials.rb
+++ b/spec/support/credentials.rb
@@ -3,15 +3,23 @@ require 'dotenv'
 Dotenv.load
 
 def creds
-  OpenStruct.new(
-    {
-      consumer_key: ENV['QBO_API_CONSUMER_KEY'],
-      consumer_secret: ENV['QBO_API_CONSUMER_SECRET'],
-      token: ENV['QBO_API_ACCESS_TOKEN'],
-      token_secret: ENV['QBO_API_ACCESS_TOKEN_SECRET'],
-      realm_id: ENV['QBO_API_COMPANY_ID']
-    }
-  )
+  if ENV['QBO_API_OAUTH2_ACCESS_TOKEN']
+    oauth2_creds
+  else
+    oauth1_creds
+  end
+end
+
+def oauth1_creds
+    OpenStruct.new(
+      {
+        consumer_key: ENV['QBO_API_CONSUMER_KEY'],
+        consumer_secret: ENV['QBO_API_CONSUMER_SECRET'],
+        token: ENV['QBO_API_ACCESS_TOKEN'],
+        token_secret: ENV['QBO_API_ACCESS_TOKEN_SECRET'],
+        realm_id: ENV['QBO_API_COMPANY_ID']
+      }
+    )
 end
 
 def oauth2_creds

--- a/spec/supporting_spec.rb
+++ b/spec/supporting_spec.rb
@@ -1,9 +1,12 @@
 require 'spec_helper'
 
 describe "QboApi::Supporting" do
+
+  let(:api){ QboApi.new(creds.to_h) }
+
+
   context ".batch" do
     it 'does 4 operations in one request' do
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/batch/basic", record: :none) do
         response = api.batch(batch_payload)
         batch_response = response['BatchItemResponse']
@@ -15,7 +18,6 @@ describe "QboApi::Supporting" do
 
   context ".reports" do
     it 'for Profit and Loss with query params' do
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/reports/profit_and_loss", record: :none) do
         params = { start_date: '2015-01-01', end_date: '2015-07-31', customer: 1, summarize_column_by: 'Customers' }
         name = 'ProfitAndLoss'
@@ -25,7 +27,6 @@ describe "QboApi::Supporting" do
     end
 
     it 'for General Ledger with no query params' do
-      api = QboApi.new(creds.to_h)
       VCR.use_cassette("qbo_api/reports/gl", record: :none) do
         name = 'GeneralLedger'
         response = api.reports(name: name)

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -2,19 +2,19 @@ require 'spec_helper'
 
 describe QboApi::Util do
 
+  let(:api){ QboApi.new(creds.to_h) }
+
+
   it 'allow string to pass thru cdc_time' do
-    api = QboApi.new(creds.to_h)
     expect(api.cdc_time("str")).to eq "str"
   end
 
   it 'convert Time objects to proper CDC "changed since" time stamp' do
-    api = QboApi.new(creds.to_h)
     expect(api.cdc_time(Time.now)).to match /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/
   end
 
   describe '.esc' do
     it "properly handles a single quote" do
-      api = QboApi.new(creds.to_h)
       expect(api.esc("Amy's Bird Sanctuary")).to eq "Amy\\'s Bird Sanctuary"
     end
   end
@@ -28,7 +28,6 @@ describe QboApi::Util do
     it "add global minor version and request id plus another parameter" do
       QboApi.minor_version = 4
       QboApi.request_id = true
-      api = QboApi.new(creds.to_h)
       path = api.entity_path(:tax_code)
       path = api.finalize_path(path, method: :post, params: { other: 12345 })
       expect(path).to match /other=12345$/
@@ -36,7 +35,6 @@ describe QboApi::Util do
 
     it "requestid is not implemented for non-post requests" do
       QboApi.request_id = true
-      api = QboApi.new(creds.to_h)
       path = api.entity_path(:tax_code)
       path = api.finalize_path(path, method: :get, params: { other: 12345 })
       expect(path).to_not match /requestid=/
@@ -50,7 +48,6 @@ describe QboApi::Util do
     end
 
     it 'is not added by default' do
-      api = QboApi.new(creds.to_h)
       path = api.entity_path(:invoice)
       path = api.add_minor_version_to(path)
       expect(path).to_not match /minorversion/
@@ -58,7 +55,6 @@ describe QboApi::Util do
 
     it 'is added when configuration minor_version = 8' do
       QboApi.minor_version = 8
-      api = QboApi.new(creds.to_h)
       path = api.entity_path(:purchase_order)
       path = api.add_minor_version_to(path)
       expect(path).to match /minorversion=8/
@@ -72,7 +68,6 @@ describe QboApi::Util do
     end
 
     it 'is not added by default' do
-      api = QboApi.new(creds.to_h)
       path = api.entity_path(:estimate)
       path = api.add_request_id_to(path)
       expect(path).to_not match /requestid/
@@ -80,7 +75,6 @@ describe QboApi::Util do
 
     it 'is added when configuration request_id = true' do
       QboApi.request_id = true
-      api = QboApi.new(creds.to_h)
       path = api.entity_path(:invoice)
       path = api.add_request_id_to(path)
       expect(path).to match /requestid/
@@ -88,7 +82,6 @@ describe QboApi::Util do
 
     it 'is properly added when other url params are set' do
       QboApi.request_id = true
-      api = QboApi.new(creds.to_h)
       path = api.entity_path(:sales_receipt)
       path = api.add_params_to_path(path: path, params: { operation: :delete, test: :true})
       path = api.add_request_id_to(path)


### PR DESCRIPTION
I've updated the specs to check for an OAuth2 token in .env. If it exists then it switches to using OAuth2 as the creds.

While doing this I DRY'ed up some specs by using let(:api) etc

I've followed your advice and put to decision to use OAuth2 credentials into the definition of creds. I did have it in the let(:api) {etc} at one point but creds was being used in a lot of places where it didn't make sense to add an extra if ... else ... 

I also added byebug gem in dev mode, as I use it a lot and missed it at one point.

I've also added a spec/temp/ directory to hold spec_status.txt which allows you to use

    rspec --next-failure

to run just the failing specs
