### PR TITLE
Updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Ruby client for the QuickBooks Online API version 3.
 - <a href="http://minimul.com/getting-started-with-the-modern-ruby-quickbooks-online-client-qbo_api-part-1.html" target="_blank">Part 1</a>: Learn how to spin up the <a href="https://github.com/minimul/qbo_api#spin-up-an-example">example app</a>.
 - <a href="http://minimul.com/the-modern-ruby-quickbooks-client-part-2.html" target="_blank">Part 2</a>: <a href="https://github.com/minimul/qbo_api#running-the-specs">Running the specs</a> to aid you in understanding a QuickBooks API transaction. 
 - <a href="http://minimul.com/the-modern-ruby-quickbooks-client-contributing.html" target="_blank">Part 3</a>: <a href="https://github.com/minimul/qbo_api#creating-new-specs-or-modifying-existing-spec-that-have-been-recorded-using-the-vcr-gem">Contributing to the gem</a>.
-
+### Important Note: The videos are out of date. 
+If you signed up for a Intuit developer account after July 17th, 2017 then you will have to
+follow <a href='#OAuth2-example'>OAuth2: Spin up an example</a>
 ## The Book
 
 <a href="https://leanpub.com/minimul-qbo-guide-vol-1" target="_blank">
@@ -332,7 +334,7 @@ See [docs](https://developer.intuit.com/docs/0100_quickbooks_online/0100_essenti
   p qbo_api.is_transaction_entity?(:customer) # => false
   p qbo_api.is_name_list_entity?(:vendors) # => true
 ```
-## OAuth2: Spin up an example
+## <a name='OAuth2-example'>OAuth2: Spin up an example</a>
 ### If you signed up for a Intuit developer account after July 17th, 2017 follow this example
 - <a href="http://minimul.com/access-the-quickbooks-online-api-with-oauth2.html" target="_blank">Check out this article on spinning up the OAuth2 example</a>.
 - `git clone git://github.com/minimul/qbo_api && cd qbo_api`


### PR DESCRIPTION
I've updated README.md to make it clear that people who signed up recently will have to use the Oauth2 example because the videos and examples linked to are out of date
