### PR TITLE
No one should be forced to install simple_oauth to use the gem

### DIFF
--- a/qbo_api.gemspec
+++ b/qbo_api.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'sinatra'
   spec.add_development_dependency 'rack-oauth2'
+  spec.add_development_dependency 'simple_oauth'
   spec.add_development_dependency 'omniauth'
   spec.add_development_dependency 'omniauth-quickbooks'
   spec.add_development_dependency 'shotgun'
@@ -33,6 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday'
   spec.add_runtime_dependency 'faraday_middleware'
   spec.add_runtime_dependency 'faraday-detailed_logger'
-  spec.add_runtime_dependency 'simple_oauth'
   spec.add_runtime_dependency 'nokogiri'
 end


### PR DESCRIPTION
But this will fail loudly and appropriately when it's needed.

```
Gem::LoadError: simple_oauth is not part of the bundle. Add it to your Gemfile.
```