### PR TITLE
RFC: Refactor splitting up auth-specific attributes

### DIFF
--- a/lib/qbo_api.rb
+++ b/lib/qbo_api.rb
@@ -57,11 +57,11 @@ class QboApi
 
   def get_endpoint
     prod = self.class.production
-    case @endpoint
-    when :accounting
-      prod ? V3_ENDPOINT_BASE_URL.sub("sandbox-", '') : V3_ENDPOINT_BASE_URL
-    when :payments
-      prod ? PAYMENTS_API_BASE_URL.sub("sandbox.", '') : PAYMENTS_API_BASE_URL
+    {
+      accounting: prod ? V3_ENDPOINT_BASE_URL.sub("sandbox-", '') : V3_ENDPOINT_BASE_URL,
+      payments: prod ? PAYMENTS_API_BASE_URL.sub("sandbox.", '') : PAYMENTS_API_BASE_URL
+    }.fetch(endpoint) do
+      raise KeyError, "Invalid endpoint: #{endpoint.inspect}"
     end
   end
 end

--- a/lib/qbo_api.rb
+++ b/lib/qbo_api.rb
@@ -45,8 +45,12 @@ class QboApi
     }
   end
 
-  def connection(url: @endpoint_url)
+  def connection(url: endpoint_url)
     @connection ||= authorized_json_connection(url)
+  end
+
+  def endpoint_url
+    @endpoint_url.dup
   end
 
   private

--- a/lib/qbo_api.rb
+++ b/lib/qbo_api.rb
@@ -22,27 +22,17 @@ class QboApi
   include Attachment
   include ApiMethods
 
-  attr_accessor :token, :token_secret
-  attr_accessor :access_token
   attr_accessor :realm_id
-  attr_accessor :consumer_key, :consumer_secret
   attr_accessor :endpoint
 
-  REQUEST_TOKEN_URL          = 'https://oauth.intuit.com/oauth/v1/get_request_token'
-  ACCESS_TOKEN_URL           = 'https://oauth.intuit.com/oauth/v1/get_access_token'
-  APP_CENTER_BASE            = 'https://appcenter.intuit.com'
-  APP_CENTER_URL             =  APP_CENTER_BASE + '/Connect/Begin?oauth_token='
   V3_ENDPOINT_BASE_URL       = 'https://sandbox-quickbooks.api.intuit.com/v3/company/'
   PAYMENTS_API_BASE_URL      = 'https://sandbox.api.intuit.com/quickbooks/v4/payments'
-  APP_CONNECTION_URL         = APP_CENTER_BASE + '/api/v1/connection'
   LOG_TAG = "[QuickBooks]"
 
   # @param attributes [Hash<Symbol,String>]
   def initialize(attributes = {})
     raise ArgumentError, "missing keyword: realm_id" unless attributes.key?(:realm_id)
     attributes = default_attributes.merge!(attributes)
-    attributes[:consumer_key] ||= (defined?(CONSUMER_KEY) ? CONSUMER_KEY : nil)
-    attributes[:consumer_secret] ||=(defined?(CONSUMER_SECRET) ? CONSUMER_SECRET : nil)
     attributes.each do |attribute, value|
       public_send("#{attribute}=", value)
     end
@@ -51,8 +41,7 @@ class QboApi
 
   def default_attributes
     {
-      token: nil, token_secret: nil, access_token: nil,
-      consumer_key: nil, consumer_secret: nil, endpoint: :accounting
+      endpoint: :accounting
     }
   end
 

--- a/lib/qbo_api.rb
+++ b/lib/qbo_api.rb
@@ -22,7 +22,11 @@ class QboApi
   include Attachment
   include ApiMethods
 
-  attr_reader :realm_id
+  attr_accessor :token, :token_secret
+  attr_accessor :access_token
+  attr_accessor :realm_id
+  attr_accessor :consumer_key, :consumer_secret
+  attr_accessor :endpoint
 
   REQUEST_TOKEN_URL          = 'https://oauth.intuit.com/oauth/v1/get_request_token'
   ACCESS_TOKEN_URL           = 'https://oauth.intuit.com/oauth/v1/get_access_token'
@@ -33,16 +37,23 @@ class QboApi
   APP_CONNECTION_URL         = APP_CENTER_BASE + '/api/v1/connection'
   LOG_TAG = "[QuickBooks]"
 
-  def initialize(token: nil, token_secret: nil, access_token: nil, realm_id:,
-                 consumer_key: nil, consumer_secret: nil, endpoint: :accounting)
-    @consumer_key = consumer_key || (defined?(CONSUMER_KEY) ? CONSUMER_KEY : nil)
-    @consumer_secret = consumer_secret || (defined?(CONSUMER_SECRET) ? CONSUMER_SECRET : nil)
-    @token = token
-    @token_secret = token_secret
-    @access_token = access_token
-    @realm_id = realm_id
-    @endpoint = endpoint
+  # @param attributes [Hash<Symbol,String>]
+  def initialize(attributes = {})
+    raise ArgumentError, "missing keyword: realm_id" unless attributes.key?(:realm_id)
+    attributes = default_attributes.merge!(attributes)
+    attributes[:consumer_key] ||= (defined?(CONSUMER_KEY) ? CONSUMER_KEY : nil)
+    attributes[:consumer_secret] ||=(defined?(CONSUMER_SECRET) ? CONSUMER_SECRET : nil)
+    attributes.each do |attribute, value|
+      public_send("#{attribute}=", value)
+    end
     @endpoint_url = get_endpoint
+  end
+
+  def default_attributes
+    {
+      token: nil, token_secret: nil, access_token: nil,
+      consumer_key: nil, consumer_secret: nil, endpoint: :accounting
+    }
   end
 
   def connection(url: @endpoint_url)

--- a/lib/qbo_api/attachment.rb
+++ b/lib/qbo_api/attachment.rb
@@ -17,7 +17,7 @@ class QboApi
     end
 
     def attachment_connection
-      @attachment_connection ||= authorized_multipart_connection(@endpoint_url)
+      @attachment_connection ||= authorized_multipart_connection(endpoint_url)
     end
 
   end

--- a/lib/qbo_api/connection/oauth1.rb
+++ b/lib/qbo_api/connection/oauth1.rb
@@ -1,0 +1,60 @@
+class QboApi
+  APP_CENTER_BASE            = 'https://appcenter.intuit.com'
+  APP_CENTER_URL             =  APP_CENTER_BASE + '/Connect/Begin?oauth_token='
+  APP_CONNECTION_URL         = APP_CENTER_BASE + '/api/v1/connection'
+
+  attr_accessor :token, :token_secret
+  attr_accessor :consumer_key, :consumer_secret
+
+  module Connection::OAuth1
+
+    def self.included(*)
+      QboApi::Connection.add_authorization_middleware :oauth1
+      super
+    end
+
+    def default_attributes
+      super.merge!(
+        token: nil, token_secret: nil,
+        consumer_key: defined?(CONSUMER_KEY) ? CONSUMER_KEY : nil,
+        consumer_secret: defined?(CONSUMER_SECRET) ? CONSUMER_SECRET : nil,
+      )
+    end
+
+    def add_oauth1_authorization_middleware(conn)
+      gem 'simple_oauth'
+      require 'simple_oauth'
+      conn.request :oauth, oauth_data
+    end
+
+    def use_oauth1_middleware?
+      token != nil
+    end
+
+    # https://developer.intuit.com/docs/0100_quickbooks_online/0100_essentials/0085_develop_quickbooks_apps/0004_authentication_and_authorization/oauth_management_api#/Reconnect
+    def disconnect
+      path = "#{APP_CONNECTION_URL}/disconnect"
+      request(:get, path: path)
+    end
+
+    # https://developer.intuit.com/docs/0100_quickbooks_online/0100_essentials/0085_develop_quickbooks_apps/0004_authentication_and_authorization/oauth_management_api#/Reconnect
+    def reconnect
+      path = "#{APP_CONNECTION_URL}/reconnect"
+      request(:get, path: path)
+    end
+
+    private
+
+    # Use with simple_oauth OAuth1 middleware
+    # @see #add_authorization_middleware
+    def oauth_data
+      {
+        consumer_key: @consumer_key,
+        consumer_secret: @consumer_secret,
+        token: @token,
+        token_secret: @token_secret
+      }
+    end
+
+  end
+end

--- a/lib/qbo_api/connection/oauth2.rb
+++ b/lib/qbo_api/connection/oauth2.rb
@@ -1,0 +1,24 @@
+class QboApi
+  attr_accessor :access_token
+
+  module Connection::OAuth2
+
+    def self.included(*)
+      QboApi::Connection.add_authorization_middleware :oauth2
+      super
+    end
+
+    def default_attributes
+      super.merge!(
+        access_token: nil
+      )
+    end
+    def add_oauth2_authorization_middleware(conn)
+      conn.request :oauth2, access_token, token_type: 'bearer'
+    end
+
+    def use_oauth2_middleware?
+      access_token != nil
+    end
+  end
+end

--- a/spec/oauth2_spec.rb
+++ b/spec/oauth2_spec.rb
@@ -5,7 +5,9 @@ describe QboApi do
   context "Use OAuth2" do
     it 'but must set an access_token' do
       api = QboApi.new realm_id: 'test'
-      expect { api.get :customer, 5 }.to raise_error QboApi::Error, "Must set either the token or access_token"
+      expect { api.get :customer, 5 }.to raise_error(QboApi::Error) {|e|
+        expect(e.message).to match(/authorization_middleware/)
+      }
     end
 
     if ENV['QBO_API_OAUTH2_ACCESS_TOKEN']


### PR DESCRIPTION
For just thinking about. We can't remove oauth1 just yet, but we'll probably want to add
the new graphql api soonish. This gives us a place to separately consider the attributes
and dependencies of each auth strategy separately.