### PR TITLE
Deactivating a transaction class requires a 'Name'

### DIFF
--- a/lib/qbo_api/api_methods.rb
+++ b/lib/qbo_api/api_methods.rb
@@ -128,7 +128,7 @@ class QboApi
       payload = build_update(resp).merge('sparse': true, 'Active': false)
 
       case singular(entity)
-      when 'Account'
+      when 'Account', 'Class'
         payload['Name'] = resp['Name']
       end
       payload


### PR DESCRIPTION
not listed in https://developer.intuit.com/docs/api/accounting/class but error message implies it

```
{:fault_type=>"ValidationFault", :error_code=>"2020", :error_message=>"Required param missing, need to supply the required value for the API", :error_detail=>"Required parameter Name is missing in the request"}]
```

TODO: validate we want to do this