### PR TITLE
Handle 502 bad gateway API response

### DIFF
--- a/lib/qbo_api/error.rb
+++ b/lib/qbo_api/error.rb
@@ -6,6 +6,7 @@
 #404 Not Found	The resource is not found.
 #429 Too Many Requests  API Throttling/ Rate limiting
 #500 Internal Server Error	An error occurred on the server while processing the request.  Resubmit request once; if it persists, contact developer support.
+#502 Bad Gateway	The server, while acting as a gateway or proxy, received an invalid response from an inbound server it accessed while attempting to fulfill the request.
 #503 Service Unavailable	The service is temporarily unavailable.
 # Custom error class for rescuing from all QuickBooks Online errors
 class QboApi
@@ -39,6 +40,9 @@ class QboApi
 
   # Raised when QuickBooks Online returns the HTTP status code 500
   class InternalServerError < Error; end
+
+  # Raised when QuickBooks Online returns the HTTP status code 502
+  class BadGateway < Error; end
 
   # Raised when QuickBooks Online returns the HTTP status code 503
   class ServiceUnavailable < Error; end

--- a/lib/qbo_api/raise_http_exception.rb
+++ b/lib/qbo_api/raise_http_exception.rb
@@ -22,7 +22,7 @@ module FaradayMiddleware
         when 500
           raise QboApi::InternalServerError.new(error_message(response))
         when 502
-          raise QboApi::BadGateway.new({ error_message: response.reason_phrase })
+          raise QboApi::BadGateway.new({ error_body: response.reason_phrase })
         when 503
           raise QboApi::ServiceUnavailable.new(error_message(response))
         end

--- a/lib/qbo_api/raise_http_exception.rb
+++ b/lib/qbo_api/raise_http_exception.rb
@@ -21,6 +21,8 @@ module FaradayMiddleware
           raise QboApi::TooManyRequests.new(error_message(response))
         when 500
           raise QboApi::InternalServerError.new(error_message(response))
+        when 502
+          raise QboApi::BadGateway.new({ error_message: response.reason_phrase })
         when 503
           raise QboApi::ServiceUnavailable.new(error_message(response))
         end


### PR DESCRIPTION
The QBO API sometimes returns 502 errors straight from NGINX. There's really not much to it, just a new error class.