### PR TITLE
README: Describe the default version used by the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ QboApi.request_id = true
   resp = qbo_api.create(:bill, payload: bill_hash, params: { requestid: qbo_api.uuid })
   # Works with .get, .create, .update, .query methods
 ```
-- To run all requests with a [Minor version](https://developer.intuit.com/docs/0100_quickbooks_online/0200_dev_guides/accounting/minor_versions).
+- By default, this client runs against the current "base" or major version of the QBO API. This client does not run against the latest QBO API [minor version](https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions) by default. To run all requests with a specific minor version, you must specify it:
 ```ruby
 QboApi.minor_version = 8
 ```


### PR DESCRIPTION
By default, the qbo_api client runs against the latest _base_ version of the QBO API, and not the latest minor version, by default and by design. This may confuse some users, since the QBO API documentation describes the latest minor version.

Explicitly describe how the client runs against the latest _base_ version of the QBO API by default, and that it does not run against the latest, or any, minor version by default.

Update the hyperlink to the QBO API minor versions documentation.

References #122.