### PR TITLE
Support passing production: ... to QboApi.new

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you're not using ActiveSupport, you'll need to use `#iso8601` method to conve
 ### Configuration options
 - By default this client runs against a QBO sandbox. To run against the production QBO API URL do:
 ```ruby
-QboApi.production = true
+QboApi.production = true # or pass `production:` to QboApi.new(...)
 ```
 - Logging:
 ```ruby

--- a/lib/qbo_api.rb
+++ b/lib/qbo_api.rb
@@ -32,6 +32,7 @@ class QboApi
   def initialize(attributes = {})
     raise ArgumentError, "missing keyword: access_token" unless attributes.key?(:access_token)
     raise ArgumentError, "missing keyword: realm_id" unless attributes.key?(:realm_id)
+    @production = attributes.delete(:production)
     attributes = default_attributes.merge!(attributes)
     attributes.each do |attribute, value|
       public_send("#{attribute}=", value)
@@ -53,13 +54,22 @@ class QboApi
     @endpoint_url.dup
   end
 
+  # Use the `production:` from initialization,
+  # or fall back to the current setting at `QboApi.production`
+  def production
+    if @production.nil?
+      self.class.production
+    else
+      @production
+    end
+  end
+
   private
 
   def get_endpoint
-    prod = self.class.production
     {
-      accounting: prod ? V3_ENDPOINT_BASE_URL.sub("sandbox-", '') : V3_ENDPOINT_BASE_URL,
-      payments: prod ? PAYMENTS_API_BASE_URL.sub("sandbox.", '') : PAYMENTS_API_BASE_URL
+      accounting: production ? V3_ENDPOINT_BASE_URL.sub("sandbox-", '') : V3_ENDPOINT_BASE_URL,
+      payments: production ? PAYMENTS_API_BASE_URL.sub("sandbox.", '') : PAYMENTS_API_BASE_URL
     }.fetch(endpoint) do
       raise KeyError, "Invalid endpoint: #{endpoint.inspect}"
     end

--- a/spec/qbo_api_spec.rb
+++ b/spec/qbo_api_spec.rb
@@ -43,11 +43,21 @@ describe QboApi do
   end
 
   it '.get_endpoint' do
+    # These two use their initialized value, not the global setting:
+    prod_api = QboApi.new(creds.merge(production: true))
+    sandbox_api = QboApi.new(creds.merge(production: false))
+
     expect(api.send(:get_endpoint)).to eq QboApi::V3_ENDPOINT_BASE_URL
+    expect(prod_api.send(:get_endpoint)).to_not match /sandbox/
+    expect(sandbox_api.send(:get_endpoint)).to match /sandbox/
+
     QboApi.production = true
     expect(api.send(:get_endpoint)).to_not match /sandbox/
     new_api = QboApi.new(creds.to_h)
     expect(new_api.send(:get_endpoint)).to_not match /sandbox/
+
+    expect(prod_api.send(:get_endpoint)).to_not match /sandbox/
+    expect(sandbox_api.send(:get_endpoint)).to match /sandbox/
     QboApi.production = false
     api = QboApi.new(creds.to_h.merge(endpoint: :payments))
     expect(api.send(:get_endpoint)).to eq QboApi::PAYMENTS_API_BASE_URL


### PR DESCRIPTION
Hi! Thanks for your work on this gem -- I've been using it to develop a new Rails-based integration for keeping inventory. 

I'm starting to get my integration in production mode, but I'd like to continue using Sandbox mode for some testing accounts. To support that, I'd like to initialize clients with their own `@production = true | false` attributes. That way, I can have some Rails requests using sandbox credentials and others using production credentials. 

I considered something like `before_action { ... }`, setting top-level `QboApi.production = ...` on a per-request basis, but I'm using a threaded Rails server and I think that configuration would leak from one request to the next, since `.production = ...` isn't thread-safe. In any case, I'm creating `QboApi` instances for each logged-in user anyways, so what I really _want_ is a per-client `production` setting. 

I have added an optional `QboApi.new(production: ...)` setting in this PR. When the parameter is not provided, it keeps the previous default behavior of dynamically checking `self.class.production`, so instances can switch modes when the top level setting changes. I think this keeps 100% compatibility with the previous code. 

What do you think about this change? Let me know if you're interested and I'd be happy to make any other improvements you recommend. 