### PR TITLE
Add optional sync_token parameter to update/delete/void/deactivate methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ QboApi.minor_version = 76
   p response.fetch('PrimaryPhone').fetch('FreeFormNumber') # => "(415) 444-1234"
 ```
 
+`update`, `delete`, `void`, and `deactivate` all send the entity's `SyncToken`, which QuickBooks uses for optimistic locking: a write is only accepted if its `SyncToken` matches the current server version. By default the gem fetches the latest `SyncToken` with a `GET` immediately before the write — which means any change that landed between your own read and your write is silently overwritten (last write wins).
+
+Pass `sync_token:` to send a `SyncToken` you obtained earlier instead. QuickBooks then rejects the write if the entity changed in the meantime, so you can read a version, decide what to do, and write back knowing nothing slipped in between. (As a side effect it also skips the extra `GET`.)
+```ruby
+  response = qbo_api.update(:customer, id: 60, payload: customer, sync_token: '2')
+```
+
 ### Delete (only works for transaction entities)
 ```ruby
   response = qbo_api.delete(:invoice, id: 145)
@@ -138,11 +145,33 @@ NOTE: If you are deleting a journal entry you have to use the following syntax w
   p response['status'] # => "Deleted"
 ```
 
+`sync_token:` is accepted here too:
+```ruby
+  response = qbo_api.delete(:invoice, id: 145, sync_token: '0')
+```
+
+### Void (only works for voidable transaction entities)
+```ruby
+  response = qbo_api.void(:invoice, id: 145)
+  p response['PrivateNote'] # => "Voided"
+```
+
+`sync_token:` is accepted here too:
+```ruby
+  response = qbo_api.void(:invoice, id: 145, sync_token: '0')
+```
+
 ### Deactivate (only works for name list entities)
 ```ruby
   response = qbo_api.deactivate(:employee, id: 55)
   p response['Active'] # => false
 ```
+
+`sync_token:` is accepted here too:
+```ruby
+  response = qbo_api.deactivate(:employee, id: 55, sync_token: '1')
+```
+NOTE: For `Account` and `Class` entities, deactivating also requires the entity's current `Name`, so the `GET` still happens in that case even if you pass `sync_token:` — but the `SyncToken` you supplied is what's sent, not the freshly fetched one.
 
 ### Get an entity by its id
 ```ruby

--- a/lib/qbo_api/api_methods.rb
+++ b/lib/qbo_api/api_methods.rb
@@ -43,31 +43,31 @@ class QboApi
       request(:post, entity: entity, path: entity_path(entity), payload: payload, params: params)
     end
 
-    def update(entity, id:, payload:, params: nil)
-      payload.merge!(set_update(entity, id))
+    def update(entity, id:, payload:, params: nil, sync_token: nil)
+      payload.merge!(set_update(entity, id, sync_token: sync_token))
       request(:post, entity: entity, path: entity_path(entity), payload: payload, params: params)
     end
 
-    def delete(entity, id:)
+    def delete(entity, id:, sync_token: nil)
       err_msg = "Delete is only for transaction entities. Use .deactivate instead"
       raise QboApi::NotImplementedError.new, err_msg unless is_transaction_entity?(entity)
       path = add_params_to_path(path: entity_path(entity), params: { operation: :delete })
-      payload = set_update(entity, id)
+      payload = set_update(entity, id, sync_token: sync_token)
       request(:post, entity: entity, path: path, payload: payload)
     end
 
-    def deactivate(entity, id:)
+    def deactivate(entity, id:, sync_token: nil)
       err_msg = "Deactivate is only for name list entities. Use .delete instead"
       raise QboApi::NotImplementedError.new, err_msg unless is_name_list_entity?(entity)
-      payload = set_deactivate(entity, id)
+      payload = set_deactivate(entity, id, sync_token: sync_token)
       request(:post, entity: entity, path: entity_path(entity), payload: payload)
     end
 
-    def void(entity, id:)
+    def void(entity, id:, sync_token: nil)
       err_msg = "Void is only for voidable transaction entities. Use .delete or .deactivate instead"
       raise QboApi::NotImplementedError.new, err_msg unless is_voidable_transaction_entity?(entity)
       path = add_params_to_path(path: entity_path(entity), params: { operation: :void })
-      payload = set_update(entity, id)
+      payload = set_update(entity, id, sync_token: sync_token)
       request(:post, entity: entity, path: path, payload: payload)
     end
 
@@ -124,28 +124,23 @@ class QboApi
       select
     end
 
-    def build_update(resp)
-      { Id: resp['Id'], SyncToken: resp['SyncToken'] }
+    def build_update(id:, sync_token:)
+      { Id: id, SyncToken: sync_token }
     end
 
-    def build_deactivate(entity, resp)
-      payload = build_update(resp).merge('sparse': true, 'Active': false)
+    def set_update(entity, id, sync_token: nil)
+      build_update(id: id, sync_token: sync_token || get(entity, id)['SyncToken'])
+    end
 
-      case singular(entity)
-      when 'Account', 'Class'
-        payload['Name'] = resp['Name']
-      end
+    def set_deactivate(entity, id, sync_token: nil)
+      needs_name = deactivate_requires_name?(entity)
+      resp = get(entity, id) if sync_token.nil? || needs_name
+
+      # A supplied sync_token always wins; we only fall back to the fetched one.
+      payload = build_update(id: id, sync_token: sync_token || resp['SyncToken'])
+                  .merge(sparse: true, Active: false)
+      payload[:Name] = resp['Name'] if needs_name
       payload
-    end
-
-    def set_update(entity, id)
-      resp = get(entity, id)
-      build_update(resp)
-    end
-
-    def set_deactivate(entity, id)
-      resp = get(entity, id)
-      build_deactivate(entity, resp)
     end
   end
 end

--- a/lib/qbo_api/entity.rb
+++ b/lib/qbo_api/entity.rb
@@ -82,6 +82,12 @@ class QboApi
       }
     end
 
+    # Account and Class reject a sparse deactivate unless the current Name is
+    # echoed back, so deactivating these always requires a fetch to read that Name.
+    def deactivate_requires_name?(entity)
+      %w[Account Class].include?(singular(entity))
+    end
+
     def supporting_entities
       %w{
         Attachable

--- a/spec/api_methods_spec.rb
+++ b/spec/api_methods_spec.rb
@@ -5,6 +5,17 @@ describe QboApi::ApiMethods do
 
   QboApi.send(:public, :to_quote_or_not)
 
+  # Proves the caller's SyncToken - not a server-fetched one - is what goes on the
+  # wire: the POST body carries exactly the supplied token, and no GET was made to
+  # fetch a fresh one first. (VCR matches on method+URI only, so webmock still
+  # records the real outgoing body for us to inspect.)
+  def expect_supplied_sync_token_sent(entity_path:, sync_token:)
+    expect(a_request(:get, %r{#{entity_path}})).not_to have_been_made
+    expect(
+      a_request(:post, %r{#{entity_path}}).with { |req| JSON.parse(req.body)['SyncToken'] == sync_token }
+    ).to have_been_made, "Expected request to have sync token '#{sync_token}' in the body, but it did not."
+  end
+
   describe "get, filtered get, and query" do
 
     it '.to_quote_or_not' do
@@ -135,19 +146,38 @@ describe QboApi::ApiMethods do
         expect(response['SyncToken'].to_i).to be > 0
       end
     end
+
+    it 'sends the supplied sync_token for a customer instead of fetching the current one' do
+      customer = {
+        DisplayName: 'Jack Moe',
+        PrimaryPhone: {
+          FreeFormNumber: "(415) 444-1234"
+        }
+      }
+      use_cassette("update/customer_with_sync_token") do
+        api.update(:customer, id: 483, payload: customer, sync_token: '99')
+        expect_supplied_sync_token_sent(entity_path: '/customer', sync_token: '99')
+      end
+    end
   end #= end '.update
 
   describe '.delete' do
-    let(:invoice_id) { "266" }
     it 'an invoice' do
       use_cassette("delete/invoice") do
-        response = api.delete(:invoice, id: invoice_id)
+        response = api.delete(:invoice, id: 266)
         expect(response['status']).to eq "Deleted"
       end
     end
 
     it 'only a transaction entity' do
-      expect { api.delete(:customer, id: invoice_id) }.to raise_error QboApi::NotImplementedError, /^Delete is only for/
+      expect { api.delete(:customer, id: 266) }.to raise_error QboApi::NotImplementedError, /^Delete is only for/
+    end
+
+    it 'sends the supplied sync_token for an invoice instead of fetching the current one' do
+      use_cassette("delete/invoice_with_sync_token") do
+        api.delete(:invoice, id: 213, sync_token: '99')
+        expect_supplied_sync_token_sent(entity_path: '/invoice', sync_token: '99')
+      end
     end
   end
 
@@ -161,6 +191,13 @@ describe QboApi::ApiMethods do
 
     it 'only a voidable entity' do
       expect { api.void(:vendor, id: 34) }.to raise_error QboApi::NotImplementedError, /^Void is only for/
+    end
+
+    it 'sends the supplied sync_token for an invoice instead of fetching the current one' do
+      use_cassette("void/invoice_with_sync_token") do
+        api.void(:invoice, id: 214, sync_token: '99')
+        expect_supplied_sync_token_sent(entity_path: '/invoice', sync_token: '99')
+      end
     end
   end
 
@@ -176,6 +213,27 @@ describe QboApi::ApiMethods do
       use_cassette("deactivate/account") do
         response = api.deactivate(:account, id: 5)
         expect(response['Active']).to eq false
+      end
+    end
+
+    it 'sends the supplied sync_token for an employee instead of fetching the current one' do
+      use_cassette("deactivate/employee_with_sync_token") do
+        api.deactivate(:employee, id: 400000001, sync_token: '99')
+        expect_supplied_sync_token_sent(entity_path: '/employee', sync_token: '99')
+      end
+    end
+
+    it 'an account with a supplied sync_token still fetches (for Name) but sends the supplied SyncToken' do
+      use_cassette("deactivate/account") do
+        # Account/Class still GET (to read the current Name), so unlike the other entities a fetch
+        # does happen here. The cassette's fetched SyncToken is "1"; we deliberately supply a
+        # different value so the assertion proves the caller's value - not the freshly fetched one -
+        # is what's sent in the payload.
+        response = api.deactivate(:account, id: 5, sync_token: '99')
+        expect(response['Active']).to eq false
+        expect(
+          a_request(:post, %r{/account\z}).with { |req| JSON.parse(req.body)['SyncToken'] == '99' }
+        ).to have_been_made, "Expected request to have sync token '99' in the body, but it did not."
       end
     end
 

--- a/spec/vcr/deactivate/employee_with_sync_token.yml
+++ b/spec/vcr/deactivate/employee_with_sync_token.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox-quickbooks.api.intuit.com/v3/company/-COMPANY_ID-/employee
+    body:
+      encoding: UTF-8
+      string: '{"Id":400000001,"SyncToken":"0","sparse":true,"Active":false}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json;charset=UTF-8
+      User-Agent:
+      - Faraday v2.14.3
+      Authorization:
+      - Bearer <OAUTH2_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 21 Jul 2026 14:14:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '433'
+      Connection:
+      - keep-alive
+      X-Envoy-Upstream-Service-Time:
+      - '1014'
+      Server:
+      - istio-envoy
+      X-Envoy-Decorator-Operation:
+      - v3-facade-service-desired-service.dev-devx-v3facadeservice-usw2-stg-ids.svc.cluster.local:8090/*
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Request-Id:
+      - 1-6a5f7ed0-369ca6e224ebf6d07531ae6a
+      X-Intuit-Upstream-Locality-Region:
+      - us-west-2
+      X-Content-Type-Options:
+      - nosniff
+      X-Spanid:
+      - 6db60a9a-dcf3-bb91-bdf1-0178c7e016b2
+      Intuit-Tid:
+      - 1-6a5f7ed0-369ca6e224ebf6d07531ae6a
+      X-Amzn-Trace-Id:
+      - Root=1-6a5f7ed0-369ca6e224ebf6d07531ae6a
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Employee":{"BillableTime":false,"domain":"QBO","sparse":false,"Id":"400000001","SyncToken":"1","MetaData":{"CreateTime":"2026-07-21T07:14:18-07:00","LastUpdatedTime":"2026-07-21T07:14:41-07:00"},"Organization":false,"GivenName":"John","FamilyName":"Doe","DisplayName":"John
+        Doe (deleted)","PrintOnCheckName":"John Doe","Active":false,"V4IDPseudonym":"002098a67ceec37e19455b8e8e5ea3c388d7a4"},"time":"2026-07-21T07:14:41.577-07:00"}'
+  recorded_at: Tue, 21 Jul 2026 14:14:41 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr/delete/invoice_with_sync_token.yml
+++ b/spec/vcr/delete/invoice_with_sync_token.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox-quickbooks.api.intuit.com/v3/company/-COMPANY_ID-/invoice?operation=delete
+    body:
+      encoding: UTF-8
+      string: '{"Id":213,"SyncToken":"0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json;charset=UTF-8
+      User-Agent:
+      - Faraday v2.14.3
+      Authorization:
+      - Bearer <OAUTH2_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 21 Jul 2026 14:07:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '97'
+      Connection:
+      - keep-alive
+      X-Envoy-Upstream-Service-Time:
+      - '357'
+      Server:
+      - istio-envoy
+      X-Envoy-Decorator-Operation:
+      - v3-facade-service-desired-service.dev-devx-v3facadeservice-usw2-stg-ids.svc.cluster.local:8090/*
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Request-Id:
+      - 1-6a5f7d1b-31d217e33b576e2d6b40ff66
+      X-Intuit-Upstream-Locality-Region:
+      - us-west-2
+      X-Spanid:
+      - cd6ee940-1b05-bc20-1af0-fd56e654bdae
+      X-Amzn-Trace-Id:
+      - Root=1-6a5f7d1b-31d217e33b576e2d6b40ff66
+      X-Content-Type-Options:
+      - nosniff
+      Intuit-Tid:
+      - 1-6a5f7d1b-31d217e33b576e2d6b40ff66
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Invoice":{"domain":"QBO","status":"Deleted","Id":"213"},"time":"2026-07-21T07:07:23.722-07:00"}'
+  recorded_at: Tue, 21 Jul 2026 14:07:23 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr/update/customer_with_sync_token.yml
+++ b/spec/vcr/update/customer_with_sync_token.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox-quickbooks.api.intuit.com/v3/company/-COMPANY_ID-/customer
+    body:
+      encoding: UTF-8
+      string: '{"DisplayName":"Jack Moe","PrimaryPhone":{"FreeFormNumber":"(415) 444-1234"},"Id":483,"SyncToken":"0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json;charset=UTF-8
+      User-Agent:
+      - Faraday v2.14.3
+      Authorization:
+      - Bearer <OAUTH2_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 21 Jul 2026 13:49:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '556'
+      Connection:
+      - keep-alive
+      X-Envoy-Upstream-Service-Time:
+      - '298'
+      Server:
+      - istio-envoy
+      X-Envoy-Decorator-Operation:
+      - v3-facade-service-desired-service.dev-devx-v3facadeservice-usw2-stg-ids.svc.cluster.local:8090/*
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Request-Id:
+      - 1-6a5f78db-166ce9ba7c143e2a7c7d8aec
+      X-Intuit-Upstream-Locality-Region:
+      - us-west-2
+      X-Spanid:
+      - ad818476-a1ae-8933-e05f-036cb68123c2
+      X-Amzn-Trace-Id:
+      - Root=1-6a5f78db-166ce9ba7c143e2a7c7d8aec
+      X-Content-Type-Options:
+      - nosniff
+      Intuit-Tid:
+      - 1-6a5f78db-166ce9ba7c143e2a7c7d8aec
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Customer":{"Taxable":true,"Job":false,"BillWithParent":false,"Balance":0,"BalanceWithJobs":0,"CurrencyRef":{"value":"USD","name":"United
+        States Dollar"},"PreferredDeliveryMethod":"Print","IsProject":false,"domain":"QBO","sparse":false,"Id":"483","SyncToken":"1","MetaData":{"CreateTime":"2026-07-21T06:47:35-07:00","LastUpdatedTime":"2026-07-21T06:49:16-07:00"},"FullyQualifiedName":"Jack
+        Moe","DisplayName":"Jack Moe","PrintOnCheckName":"Jack Moe","Active":true,"PrimaryPhone":{"FreeFormNumber":"(415)
+        444-1234"}},"time":"2026-07-21T06:49:15.995-07:00"}'
+  recorded_at: Tue, 21 Jul 2026 13:49:16 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr/void/invoice_with_sync_token.yml
+++ b/spec/vcr/void/invoice_with_sync_token.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox-quickbooks.api.intuit.com/v3/company/-COMPANY_ID-/invoice?operation=void
+    body:
+      encoding: UTF-8
+      string: '{"Id":214,"SyncToken":"0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json;charset=UTF-8
+      User-Agent:
+      - Faraday v2.14.3
+      Authorization:
+      - Bearer <OAUTH2_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 21 Jul 2026 14:12:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1207'
+      Connection:
+      - keep-alive
+      X-Envoy-Upstream-Service-Time:
+      - '574'
+      Server:
+      - istio-envoy
+      X-Envoy-Decorator-Operation:
+      - v3-facade-service-desired-service.dev-devx-v3facadeservice-usw2-stg-ids.svc.cluster.local:8090/*
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Request-Id:
+      - 1-6a5f7e47-13c0bf725c62f0c54e0c8a5c
+      X-Intuit-Upstream-Locality-Region:
+      - us-west-2
+      X-Spanid:
+      - 4df03851-8f3d-1b47-094e-21b45aeb5ae2
+      X-Amzn-Trace-Id:
+      - Root=1-6a5f7e47-13c0bf725c62f0c54e0c8a5c
+      X-Content-Type-Options:
+      - nosniff
+      Intuit-Tid:
+      - 1-6a5f7e47-13c0bf725c62f0c54e0c8a5c
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Invoice":{"AllowIPNPayment":false,"AllowOnlinePayment":true,"AllowOnlineCreditCardPayment":true,"AllowOnlineACHPayment":true,"domain":"QBO","sparse":false,"Id":"214","SyncToken":"1","MetaData":{"CreateTime":"2026-07-21T07:12:04-07:00","LastModifiedByRef":{"value":"9341457536842450"},"LastUpdatedTime":"2026-07-21T07:12:24-07:00"},"CustomField":[],"DocNumber":"1039","TxnDate":"2026-07-21","CurrencyRef":{"value":"USD","name":"United
+        States Dollar"},"PrivateNote":"Voided","LinkedTxn":[],"Line":[{"Id":"1","LineNum":1,"Description":"Test","Amount":0,"DetailType":"SalesItemLineDetail","SalesItemLineDetail":{"ItemRef":{"value":"25","name":"Hours"},"Qty":0,"ItemAccountRef":{"value":"121","name":"Services"},"TaxCodeRef":{"value":"NON"}},"CustomExtensions":[]},{"Amount":0,"DetailType":"SubTotalLineDetail","SubTotalLineDetail":{}}],"CustomerRef":{"value":"482","name":"Example
+        Customer"},"CustomerMemo":{"value":"Thank you for your business and have a
+        great day!"},"BillAddr":{"Id":"407"},"ShipAddr":{"Id":"407"},"FreeFormAddress":true,"DueDate":"2026-07-21","TotalAmt":0,"ApplyTaxAfterDiscount":false,"PrintStatus":"NeedToPrint","EmailStatus":"NotSet","Balance":0},"time":"2026-07-21T07:12:24.045-07:00"}'
+  recorded_at: Tue, 21 Jul 2026 14:12:24 GMT
+recorded_with: VCR 6.4.0


### PR DESCRIPTION
QuickBooks uses `SyncToken` for optimistic locking — a write is only accepted if its token matches the current server version. Currently, the gem always fetches the latest `SyncToken` with a `GET` immediately before each `update`/`delete`/`void`/`deactivate`.

This adds an optional `sync_token:` argument to those four methods. When supplied, the gem sends *that* token instead of fetching a fresh one, so a caller can read a version, decide, and write back knowing nothing changed in between (QBO rejects the write otherwise). It also skips the extra `GET`.

- `Account`/`Class` deactivation still issues a `GET` (it needs the current `Name`), but the supplied `SyncToken` is what's sent.
- README documents the behavior and the `Account`/`Class` caveat.
- Specs added with VCR cassettes; each asserts the supplied token is what goes on the wire and (for the non-`Account` paths) that no `GET` is made.

Note: This PR was made with the help of Claude Code. That being said, I take ownership for every line in the PR.